### PR TITLE
Ticket conference names and grid columns

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -8,7 +8,7 @@
       </list>
     </option>
   </component>
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_17" default="true" project-jdk-name="openjdk-21" project-jdk-type="JavaSDK">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_21" default="true" project-jdk-name="openjdk-21" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/out" />
   </component>
 </project>

--- a/Vaadin/capstone-2024/src/main/java/com/example/application/views/collegebasketballprediction/CollegeBasketballPredictionsView.java
+++ b/Vaadin/capstone-2024/src/main/java/com/example/application/views/collegebasketballprediction/CollegeBasketballPredictionsView.java
@@ -47,6 +47,8 @@ public class CollegeBasketballPredictionsView extends Composite<VerticalLayout> 
     private List<Game> games; // list to hold all games
     private Grid<Game> grid; // the grid to display the games
 
+    private static List<String> conferenceNames;
+
     public CollegeBasketballPredictionsView() {
 
         // general page formatting
@@ -70,13 +72,11 @@ public class CollegeBasketballPredictionsView extends Composite<VerticalLayout> 
         datePicker.setLabel("Select Date");
         datePicker.setWidth("min-content");
         datePicker.setValue(LocalDate.now());
-        //datePicker.addValueChangeListener(event -> updateGridData(event.getValue()));
 
         // CONFERENCE SELECTOR: formatting and settings for the conference dropdown selector object
         ComboBox comboBox = new ComboBox();
         comboBox.setLabel("Select Conference");
         comboBox.setWidth("min-content");
-        setComboBoxData(comboBox); // Call another method to fill in the information for the conferences
 
         // TEAM SEARCH BAR: formatting and settings for the conference dropdown selector object
         TextField textField = new TextField();
@@ -85,10 +85,9 @@ public class CollegeBasketballPredictionsView extends Composite<VerticalLayout> 
 
 
         // action listeners for date, conference, and team search
-        datePicker.addValueChangeListener(event -> updateGridData(event.getValue(), comboBox.getValue().toString()));
-        comboBox.addValueChangeListener(event -> updateGridData(datePicker.getValue(), event.getValue().toString()));
-        //textField.addValueChangeListener(event -> updateGridData(datePicker.getValue(), event.getValue().toString(), textField.getValue().toString()));
-
+        datePicker.addValueChangeListener(event -> updateGridData(event.getValue(), comboBox.getValue().toString(), textField.getValue().toString()));
+        comboBox.addValueChangeListener(event -> updateGridData(datePicker.getValue(), event.getValue().toString(), textField.getValue().toString()));
+        textField.addValueChangeListener(event -> updateGridData(datePicker.getValue(), comboBox.getValue().toString(), event.getValue().toString()));
 
 
         // GAME GRID: formatting and settings and initialization
@@ -96,7 +95,8 @@ public class CollegeBasketballPredictionsView extends Composite<VerticalLayout> 
         grid.setWidth("100%");
         grid.getStyle().set("flex-grow", "0");
         setGridData(grid); // Reads in data and adds to grid
-        updateGridData(LocalDate.now(), comboBox.getValue().toString()); // Update data immediately to grab games for today
+        setComboBoxData(comboBox); // Call another method to fill in the information for the conferences
+        updateGridData(LocalDate.now(), comboBox.getValue().toString(), textField.getValue().toString()); // Update data immediately to grab games for today
 
         // Add and display everything to the page
         getContent().add(layoutRow);
@@ -115,7 +115,8 @@ public class CollegeBasketballPredictionsView extends Composite<VerticalLayout> 
      **/
     private void setComboBoxData(ComboBox comboBox) {
 
-        // List of all conferences
+        // List of all conferences for debuggin
+        /*
         List<String> items = new ArrayList<>(
                 Arrays.asList("All", "American East", "American Athletic", "A-10",
                         "Atlantic Coast", "Atlantic Sun", "Big 12", "Big East", "Big Sky",
@@ -125,6 +126,19 @@ public class CollegeBasketballPredictionsView extends Composite<VerticalLayout> 
                         "Northeast", "Ohio Valley", "Pac-12", "Patriot League", "Southeastern",
                         "Southern", "Southland", "Southwestern Athletic", "Summit League",
                         "Sun Belt", "West Coast", "Western Athletic"));
+
+         */
+
+        // List of conferences
+        List<String> items = new ArrayList<>();
+        items.add("All"); // add an All Conferences option
+
+        // add each conference name from the .csv (these values were grabbed when the grid
+        // is created through the loadGamesFromCSV method)
+        for (int i = 1; i < conferenceNames.size(); i++)
+        {
+            items.add(conferenceNames.get(i));
+        }
 
         // add all conferences to box
         comboBox.setItems(items);
@@ -142,7 +156,8 @@ public class CollegeBasketballPredictionsView extends Composite<VerticalLayout> 
 
         // create columns and label headers
         grid.addColumn(Game::getTeams).setHeader("Game").setSortable(false).setKey("Teams");
-        grid.addColumn(Game::getScores).setHeader("Score (Home - Visitor)").setSortable(false).setKey("Scores");
+        grid.addColumn(Game::getScores).setHeader("Predicted Score (Home - Visitor)").setSortable(false).setKey("Scores");
+        grid.addColumn(Game::getScores).setHeader("Actual Score (Home - Visitor)").setSortable(false).setKey("Scores");
         grid.addColumn(Game::getPercents).setHeader("Win % (Home - Visitor)").setSortable(false).setKey("Percent");
 
         // try and get games from .csv file
@@ -171,9 +186,13 @@ public class CollegeBasketballPredictionsView extends Composite<VerticalLayout> 
         // list for games
         List<Game> games = new ArrayList<>();
 
+        // list for conferences (for the combobox)
+        conferenceNames = new ArrayList<>();
+
         // get file
         ClassPathResource resource = new ClassPathResource("Schedule.csv");
         InputStream inputStream = resource.getInputStream();
+
 
         // try and get the data for each game
         try (BufferedReader br = new BufferedReader(new InputStreamReader(inputStream))) {
@@ -187,6 +206,10 @@ public class CollegeBasketballPredictionsView extends Composite<VerticalLayout> 
                 if (values.length == 2) {
                     homeTeam = values[0];
                     conference = values[1]; // Not using this right now, can check against the combobox
+                    if (!conferenceNames.contains(conference))
+                    {
+                        conferenceNames.add(conference);
+                    }
                 }
 
                 // Read lines that have game data (not byes), and where the home team is at home
@@ -219,33 +242,68 @@ public class CollegeBasketballPredictionsView extends Composite<VerticalLayout> 
      *
      *
      **/
-    private void updateGridData(LocalDate selectedDate, String conference) {
+    private void updateGridData(LocalDate selectedDate, String conference, String search) {
+
         // System.out.println("here: " + selectedDate); // debug
-
-        System.out.println("here: " + selectedDate + ", " + conference); // debug
-
+        //System.out.println("here: " + selectedDate + ", " + conference + ", " + search); // debug
 
 
-        // Grab the sublist of games from the selected date
-        if (selectedDate != null && conference != null) {
+        // if the search bar contains any text
+        if (search != null)
+        {
+            // if a date and conference have both been selected
+            if (selectedDate != null && conference != null) {
 
-            if (conference != "All")
-            {
-                List<Game> filteredGames = games.stream()
-                        .filter(game -> (game.getGameDate().equals(selectedDate) && (game.getConference().contains(conference))))
-                                .collect(Collectors.toList());
-                grid.setItems(filteredGames);
+                // a conference other than "All" has been selected
+                if (conference != "All")
+                {
+                    List<Game> filteredGames = games.stream()
+                            .filter(game -> (game.getGameDate().equals(selectedDate) && (game.getConference().contains(conference)) && ((game.getHomeTeam().contains(search)) || (game.getAwayTeam().contains(search)))))
+                            .collect(Collectors.toList());
+                    grid.setItems(filteredGames);
+                }
+
+                // otherwise just grab the games on the specified date
+                else
+                {
+                    List<Game> filteredGames = games.stream()
+                            .filter(game -> (game.getGameDate().equals(selectedDate)) && ((game.getHomeTeam().contains(search)) || (game.getAwayTeam().contains(search))))
+                            .collect(Collectors.toList());
+                    grid.setItems(filteredGames);
+                }
+            } else {
+                grid.setItems((Game) null); // Clear the grid or handle a null date as needed
             }
-            else
-            {
-                List<Game> filteredGames = games.stream()
-                        .filter(game -> game.getGameDate().equals(selectedDate))
-                        .collect(Collectors.toList());
-                grid.setItems(filteredGames);
-            }
-        } else {
-            grid.setItems((Game) null); // Clear the grid or handle a null date as needed
         }
+        else {
+
+            // Grab the sublist of games from the selected date and conference
+            if (selectedDate != null && conference != null) {
+
+                // a conference other than "All" has been selected
+                if (conference != "All")
+                {
+                    List<Game> filteredGames = games.stream()
+                            .filter(game -> (game.getGameDate().equals(selectedDate) && (game.getConference().contains(conference))))
+                            .collect(Collectors.toList());
+                    grid.setItems(filteredGames);
+                }
+
+                // otherwise just grab the games on the specified date
+                else
+                {
+                    List<Game> filteredGames = games.stream()
+                            .filter(game -> game.getGameDate().equals(selectedDate))
+                            .collect(Collectors.toList());
+                    grid.setItems(filteredGames);
+                }
+            } else {
+                grid.setItems((Game) null); // Clear the grid or handle a null date as needed
+            }
+
+        }
+
+
     }
 
 }

--- a/Vaadin/capstone-2024/src/main/java/com/example/application/views/collegebasketballprediction/CollegeBasketballPredictionsView.java
+++ b/Vaadin/capstone-2024/src/main/java/com/example/application/views/collegebasketballprediction/CollegeBasketballPredictionsView.java
@@ -156,8 +156,8 @@ public class CollegeBasketballPredictionsView extends Composite<VerticalLayout> 
 
         // create columns and label headers
         grid.addColumn(Game::getTeams).setHeader("Game").setSortable(false).setKey("Teams");
-        grid.addColumn(Game::getScores).setHeader("Predicted Score (Home - Visitor)").setSortable(false).setKey("Scores");
-        grid.addColumn(Game::getScores).setHeader("Actual Score (Home - Visitor)").setSortable(false).setKey("Scores");
+        grid.addColumn(Game::getScores).setHeader("Predicted Score (Home - Visitor)").setSortable(false).setKey("Predicted Scores");
+        grid.addColumn(Game::getScores).setHeader("Actual Score (Home - Visitor)").setSortable(false).setKey("Actual Scores");
         grid.addColumn(Game::getPercents).setHeader("Win % (Home - Visitor)").setSortable(false).setKey("Percent");
 
         // try and get games from .csv file

--- a/Vaadin/capstone-2024/src/main/java/com/example/application/views/collegebasketballprediction/CollegeBasketballPredictionsView.java
+++ b/Vaadin/capstone-2024/src/main/java/com/example/application/views/collegebasketballprediction/CollegeBasketballPredictionsView.java
@@ -100,7 +100,6 @@ public class CollegeBasketballPredictionsView extends Composite<VerticalLayout> 
         textField.setLabel("Search for a Team");
         textField.setWidth("min-content");
 
-
         /********************************
          *
          * GAME GRID
@@ -109,7 +108,6 @@ public class CollegeBasketballPredictionsView extends Composite<VerticalLayout> 
          * the grid that displays all of the basketball games
          *
          ********************************/
-
 
         // GAME GRID: formatting and settings and initialization
         grid = new Grid();
@@ -138,7 +136,6 @@ public class CollegeBasketballPredictionsView extends Composite<VerticalLayout> 
         // default conference to option 1: 'ALL'
         comboBox.setValue(items.get(0));
 
-
         /********************************
          *
          * ACTION LISTENERS
@@ -152,7 +149,6 @@ public class CollegeBasketballPredictionsView extends Composite<VerticalLayout> 
         datePicker.addValueChangeListener(event -> updateGridData(event.getValue(), comboBox.getValue().toString(), textField.getValue()));
         comboBox.addValueChangeListener(event -> updateGridData(datePicker.getValue(), event.getValue().toString(),textField.getValue()));
         textField.addValueChangeListener(event -> updateGridData(datePicker.getValue(), comboBox.getValue().toString(), event.getValue()));
-
 
         /**********************************
          *
@@ -192,8 +188,7 @@ public class CollegeBasketballPredictionsView extends Composite<VerticalLayout> 
 
         // create columns and label headers
         grid.addColumn(Game::getTeams).setHeader("Game").setSortable(false).setKey("Teams");
-        grid.addColumn(Game::getScores).setHeader("Predicted Score (Home - Visitor)").setSortable(false).setKey("Predicted Scores");
-        grid.addColumn(Game::getScores).setHeader("Actual Score (Home - Visitor)").setSortable(false).setKey("Actual Scores");
+        grid.addColumn(Game::getScores).setHeader("Score (Home - Visitor)").setSortable(false).setKey("Scores");
         grid.addColumn(Game::getPercents).setHeader("Win % (Home - Visitor)").setSortable(false).setKey("Percent");
 
         // try and get games from .csv file
@@ -207,7 +202,6 @@ public class CollegeBasketballPredictionsView extends Composite<VerticalLayout> 
 
         // put games in grid
         grid.setItems(games);
-
     }
 
     /**********************************
@@ -223,9 +217,6 @@ public class CollegeBasketballPredictionsView extends Composite<VerticalLayout> 
 
         // list for games
         List<Game> games = new ArrayList<>();
-
-        // list for conferences (for the combobox)
-        //conferenceNames = new ArrayList<>();
 
         // get file
         ClassPathResource resource = new ClassPathResource("Schedule.csv");
@@ -270,7 +261,6 @@ public class CollegeBasketballPredictionsView extends Composite<VerticalLayout> 
         // return the full list of games
         return games;
     }
-
 
     /**********************************
      *

--- a/Vaadin/capstone-2024/src/main/java/com/example/application/views/collegebasketballprediction/Game.java
+++ b/Vaadin/capstone-2024/src/main/java/com/example/application/views/collegebasketballprediction/Game.java
@@ -4,21 +4,14 @@ import java.time.LocalDate;
 
 public class Game {
 
-    private String homeTeam;
-
-    private String awayTeam;
-
-    private String homeScore;
-
-    private String awayScore;
-
-    private String homePercent;
-
-    private String awayPercent;
-
-    private LocalDate gameDate;
-
-    private String conference;
+    private String homeTeam; // home team name
+    private String awayTeam; // away team name
+    private String homeScore; // home team score
+    private String awayScore; // away team score
+    private String homePercent; // home team win percent
+    private String awayPercent; // away team win percent
+    private LocalDate gameDate; // date of game
+    private String conference; // home team conference name
 
     public Game (String homeTeam, String awayTeam, String homeScore, String awayScore,
                  String homePercent, String awayPercent, LocalDate gameDate, String conference) {


### PR DESCRIPTION
I fixed the conference names so now it is pulling all of their names directly from the .csv file containing the game data. I also added another grid column for "Predicted Score" and "Actual Score". These grid columns are a single line of code to implement so it is super easy to add and remove as needed once we get everything connected. 